### PR TITLE
Treat ["add"] same as ["sum"] in GTConv aggregation

### DIFF
--- a/gt_pyg/nn/gt_conv.py
+++ b/gt_pyg/nn/gt_conv.py
@@ -52,7 +52,7 @@ class GTConv(MessagePassing):
             aggregators = ["sum"]
 
         # Choose aggregation
-        if len(aggregators) == 1 and aggregators[0] == "sum":
+        if len(aggregators) == 1 and aggregators[0] in ("sum", "add"):
             aggr = "add"
         else:
             aggr = MultiAggregation(aggregators, mode="cat")


### PR DESCRIPTION
## Summary
- `["add"]` now takes the same lightweight built-in aggregation path as `["sum"]` in GTConv, instead of being unnecessarily wrapped in `MultiAggregation`