### PR TITLE
Fix audit #1, #20, #21; remove #22

### DIFF
--- a/gt_pyg/data/atom_features.py
+++ b/gt_pyg/data/atom_features.py
@@ -26,9 +26,9 @@ NEG_IONIZABLE_SMARTS = Chem.MolFromSmarts("[CX3](=O)[O-,OH]")
 # -----------------------------
 RING_COUNT_CATEGORIES = [0, 1, 2, 3, "MoreThanThree"]
 RING_SIZE_CATEGORIES = [3, 4, 5, 6, 7, 8, 9, 10, "MoreThanTen"]
-PERIOD_CATEGORIES = [1, 2, 3, 4, 5, 6, 7, "Unknown"]
+PERIOD_CATEGORIES = [1, 2, 3, 4, 5, 6, 7]
 # 0 is used for "no group / undefined" (e.g. some f-block elements if RDKit returns 0)
-GROUP_CATEGORIES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, "Unknown"]
+GROUP_CATEGORIES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
 
 # Permitted list of atoms for one-hot encoding
 PERMITTED_ATOMS = [

--- a/gt_pyg/data/utils.py
+++ b/gt_pyg/data/utils.py
@@ -83,7 +83,15 @@ def _canonicalize_mol(
                     chg = atom.GetFormalCharge()
                     hcount = atom.GetTotalNumHs()
                     atom.SetFormalCharge(0)
-                    atom.SetNumExplicitHs(hcount - chg)
+                    new_hcount = hcount - chg
+                    if new_hcount < 0:
+                        logging.warning(
+                            "Charge neutralization would set negative H count "
+                            "(%d) on atom %d; clamping to 0",
+                            new_hcount, at_idx,
+                        )
+                        new_hcount = 0
+                    atom.SetNumExplicitHs(new_hcount)
                     atom.UpdatePropertyCache()
 
         return mol

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,10 @@
-import subprocess
-
 from setuptools import setup, find_packages
 
-
-def _git_version() -> str:
-    """Derive a PEP 440 version from ``git describe``."""
-    try:
-        desc = (
-            subprocess.check_output(
-                ["git", "describe", "--tags", "--long"],
-                stderr=subprocess.DEVNULL,
-            )
-            .decode()
-            .strip()
-            .lstrip("v")
-        )
-        version, distance, sha = desc.rsplit("-", 2)
-        if int(distance) == 0:
-            return version
-        return f"{version}.dev{distance}+{sha}"
-    except Exception:
-        return "0.0.0"
-
+exec(open("gt_pyg/_version.py").read())
 
 setup(
     name="gt_pyg",
-    version=_git_version(),
+    version=__version__,
     description="Implementation of the Graph Transformer architecture in Pytorch-geometric",
     packages=find_packages(exclude=["tests*", "*.tests", "*.tests.*"]),
     install_requires=[


### PR DESCRIPTION
## Summary
- Clamp hydrogen count to 0 in charge neutralization to prevent negative values
- Remove unreachable "Unknown" sentinels from PERIOD_CATEGORIES and GROUP_CATEGORIES (-2 wasted dims)
- Deduplicate version parsing — setup.py now execs _version.py instead of reimplementing git describe logic
- Removed from audit (style choice, kept as-is)

## Test plan
- [x] `python setup.py --version` returns correct version
- [x] `pytest gt_pyg/` — all 25 tests pass