### PR TITLE
Return period 0 for dummy atoms; document weights_only=False

### DIFF
--- a/gt_pyg/data/atom_features.py
+++ b/gt_pyg/data/atom_features.py
@@ -26,7 +26,7 @@ NEG_IONIZABLE_SMARTS = Chem.MolFromSmarts("[CX3](=O)[O-,OH]")
 # -----------------------------
 RING_COUNT_CATEGORIES = [0, 1, 2, 3, "MoreThanThree"]
 RING_SIZE_CATEGORIES = [3, 4, 5, 6, 7, 8, 9, 10, "MoreThanTen"]
-PERIOD_CATEGORIES = [1, 2, 3, 4, 5, 6, 7]
+PERIOD_CATEGORIES = [0, 1, 2, 3, 4, 5, 6, 7]
 # 0 is used for "no group / undefined" (e.g. some f-block elements if RDKit returns 0)
 GROUP_CATEGORIES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
 
@@ -168,7 +168,10 @@ def get_period(atomic_num: int) -> int:
     # Period 6: Cs(55) to Rn(86)
     # Period 7: Fr(87) onwards
     if atomic_num <= 0:
-        return 1
+        logging.warning(
+            "Dummy/invalid atomic number %d mapped to period 0", atomic_num,
+        )
+        return 0
     elif atomic_num <= 2:
         return 1
     elif atomic_num <= 10:

--- a/gt_pyg/nn/checkpoint.py
+++ b/gt_pyg/nn/checkpoint.py
@@ -84,6 +84,8 @@ def load_checkpoint(
     Returns:
         Checkpoint dict with state_dict, config, etc.
     """
+    # NOTE: weights_only=False is intentional — checkpoints store non-tensor
+    # metadata (config dicts, version strings, etc.).  Only load files you trust.
     checkpoint = torch.load(path, map_location=map_location, weights_only=False)
 
     saved_version = checkpoint.get("gt_pyg_version")
@@ -116,6 +118,7 @@ def get_checkpoint_info(path: Union[str, Path]) -> Dict[str, Any]:
     Returns:
         Dict with version, created_at, config, epoch, etc. (no state_dicts).
     """
+    # NOTE: weights_only=False is intentional — see load_checkpoint above.
     checkpoint = torch.load(path, map_location="cpu", weights_only=False)
     info = {}
     for key in ["checkpoint_version", "gt_pyg_version", "created_at",


### PR DESCRIPTION
## Summary
- `get_period()` now returns 0 (with a warning) for dummy/invalid atomic numbers instead of 1, so dummy atoms are no longer conflated with hydrogen. Added 0 to `PERIOD_CATEGORIES`.
- Added comments to both `torch.load(..., weights_only=False)` calls in `checkpoint.py` documenting the choice as intentional.

## Test plan
- [x] `pytest gt_pyg/` — all 25 tests pass