### PR TITLE
Fix docstrings, README, and add convenience exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ gt = GTConv(node_in_dim=num_node_features,
             edge_in_dim=num_edge_features,
             hidden_dim=15,
             num_heads=3)
-gt(x=x, edge_index=edge_index, edge_attr=edge_attr)
+x_out, edge_out = gt(x=x, edge_index=edge_index, edge_attr=edge_attr)
 ```
 
 The code also supports custom datasets. For example, if you have a file called `solubility.csv`

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - ncurses=6.4=hcec6c5f_0
   - openssl=1.1.1t=hca72f7f_0
   - pip=22.3.1=py37hecd8cb5_0
-  - python=3.7.16=h218abb5_0
+  - python=3.10
   - readline=8.2=hca72f7f_0
   - setuptools=65.6.3=py37hecd8cb5_0
   - sqlite=3.41.2=h6c40b1e_0

--- a/gt_pyg/__init__.py
+++ b/gt_pyg/__init__.py
@@ -1,3 +1,13 @@
 from gt_pyg._version import __version__
+from gt_pyg.nn.model import GraphTransformerNet
+from gt_pyg.nn.gt_conv import GTConv
+from gt_pyg.nn.mlp import MLP
+from gt_pyg.data.utils import get_tensor_data
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    "GraphTransformerNet",
+    "GTConv",
+    "MLP",
+    "get_tensor_data",
+]

--- a/gt_pyg/data/atom_features.py
+++ b/gt_pyg/data/atom_features.py
@@ -390,9 +390,9 @@ def get_atom_feature_dim(
     """Return the dimensionality of the atom feature vector.
 
     Calculates the expected length of the feature vector based on the
-    configuration options.  The returned dimension includes the GNM
-    (Kirchhoff pseudoinverse diagonal) term appended by
-    :func:`get_tensor_data`.
+    configuration options.  This does **not** include the GNM
+    (Kirchhoff pseudoinverse diagonal) term, which is appended
+    separately by :func:`get_tensor_data`.
 
     Args:
         use_stereochemistry (bool, optional): Whether stereochemistry features are included.

--- a/gt_pyg/data/utils.py
+++ b/gt_pyg/data/utils.py
@@ -145,15 +145,13 @@ def get_ring_membership_stats(
 ) -> Tuple[Dict[int, Dict[str, Any]], Dict[int, Dict[str, Any]]]:
     """Precompute ring membership statistics for atoms and bonds.
 
+    Args:
+        mol (Chem.Mol): RDKit molecule.
+
     Returns:
-        atom_ring_stats: dict[atom_idx] -> {
-            'count': int,
-            'min_size': Optional[int],
-            'max_size': Optional[int],
-            'has_aromatic': bool,
-            'has_non_aromatic': bool,
-        }
-        bond_ring_stats: dict[bond_idx] -> same structure
+        Tuple of (atom_ring_stats, bond_ring_stats). Each is a dict
+        mapping index to ``{'count', 'min_size', 'max_size',
+        'has_aromatic', 'has_non_aromatic'}``.
     """
     ring_info = mol.GetRingInfo()
     atom_rings = ring_info.AtomRings()  # tuple of tuples of atom indices

--- a/gt_pyg/nn/gt_conv.py
+++ b/gt_pyg/nn/gt_conv.py
@@ -330,6 +330,9 @@ class GTConv(MessagePassing):
         V_j: [E, H, Dh]
         G_j: [E, H, Dh] or None
         edge_attr: [E, edge_in_dim] or None
+
+        Returns:
+            Tensor: Attention-weighted values [E, H, Dh].
         """
         Dh = self.head_dim
 

--- a/gt_pyg/nn/model.py
+++ b/gt_pyg/nn/model.py
@@ -38,6 +38,7 @@ class GraphTransformerNet(nn.Module):
         dropout: float = 0.1,
         num_tasks: int = 1,
     ) -> None:
+        """Initialize the Graph Transformer network."""
         super().__init__()
 
         if gt_aggregators is None:

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         "torch>=1.13.0",
         "torch_geometric",
         "numpy",
+        "pandas",
         "rdkit",
         "tqdm",
     ],


### PR DESCRIPTION
## Summary
- Fix `get_atom_feature_dim()` docstring — clarify GNM feature is not included
- Add minimal `__init__` docstring to `GraphTransformerNet`
- Add Returns section to `GTConv.message()`
- Reformat `get_ring_membership_stats()` docstring to standard Args/Returns style
- Fix README GTConv example to capture return values
- Add `pandas` to `setup.py` install_requires
- Update `environment.yml` Python version to 3.10
- Add convenience imports (`GraphTransformerNet`, `GTConv`, `MLP`, `get_tensor_data`) to `gt_pyg/__init__.py`

## Test plan
- [x] All 25 tests pass
- [x] `from gt_pyg import GraphTransformerNet, get_tensor_data` works