### PR TITLE
Fix GNM divide-by-zero warning and document variational forward

### DIFF
--- a/gt_pyg/data/tests/test_gnm.py
+++ b/gt_pyg/data/tests/test_gnm.py
@@ -1,5 +1,7 @@
 """Tests for GNM (Gaussian Network Model) encodings."""
 
+import warnings
+
 import numpy as np
 from numpy.linalg import pinv
 
@@ -40,3 +42,23 @@ def test_gnm_symmetric_molecule():
 
     assert result.shape == (4,)
     np.testing.assert_allclose(result, result[0], atol=1e-12)
+
+
+def test_gnm_single_atom_no_warning():
+    """Single-atom molecule (1x1 zero adjacency) should not produce warnings."""
+    adj = np.array([[0]], dtype=float)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # Convert warnings to errors
+        result = get_gnm_encodings(adj)
+
+    assert result.shape == (1,)
+    assert result[0] == 0.0
+
+
+def test_gnm_single_atom_returns_zero():
+    """Single-atom GNM diagonal should be zero (no connectivity)."""
+    adj = np.array([[0]], dtype=float)
+    result = get_gnm_encodings(adj)
+
+    np.testing.assert_allclose(result, [0.0], atol=1e-12)

--- a/gt_pyg/data/utils.py
+++ b/gt_pyg/data/utils.py
@@ -229,7 +229,9 @@ def get_gnm_encodings(adjacency: np.ndarray) -> np.ndarray:
     kirchhoff = degree - adjacency
     eigenvalues, eigenvectors = np.linalg.eigh(kirchhoff)
     # Invert non-zero eigenvalues (skip the near-zero translational mode)
-    inv_eigenvalues = np.where(np.abs(eigenvalues) > 1e-10, 1.0 / eigenvalues, 0.0)
+    mask = np.abs(eigenvalues) > 1e-10
+    inv_eigenvalues = np.zeros_like(eigenvalues)
+    np.divide(1.0, eigenvalues, out=inv_eigenvalues, where=mask)
     # Diagonal of Q @ diag(inv_eigenvalues) @ Q^T = sum of Q_ij^2 * inv_eigenvalues_j
     return (eigenvectors ** 2) @ inv_eigenvalues
 


### PR DESCRIPTION
## Summary
- Replace `np.where` with `np.divide(out=, where=)` in `get_gnm_encodings` to avoid `RuntimeWarning` on single-atom molecules (eigenvalue of zero)
- Expand `GraphTransformerNet` class and `forward()` docstrings to document the variational (Gaussian) readout, reparameterization trick, and `zero_var` semantics
- Add 7 new tests (2 GNM edge cases, 5 variational forward pass behaviors)

## Test plan
- [x] `test_gnm_single_atom_no_warning` — single-atom adjacency triggers no warnings
- [x] `test_gnm_single_atom_returns_zero` — isolated atom gets zero GNM encoding
- [x] `test_eval_mode_deterministic` — repeated eval calls produce identical output
- [x] `test_train_mode_stochastic` — different seeds produce different output
- [x] `test_zero_var_deterministic_in_train` — `zero_var=True` suppresses reparameterization noise
- [x] `test_log_var_always_returned` — log_var returned in both train and eval modes
- [x] `test_log_var_clamped` — log_var values within [-10, 10]
- [x] Full suite: 118 tests pass