### PR TITLE
Fix GNM divide-by-zero for single-atom molecules

### DIFF
--- a/gt_pyg/data/tests/test_gnm.py
+++ b/gt_pyg/data/tests/test_gnm.py
@@ -1,5 +1,7 @@
 """Tests for GNM (Gaussian Network Model) encodings."""
 
+import warnings
+
 import numpy as np
 from numpy.linalg import pinv
 
@@ -40,3 +42,24 @@ def test_gnm_symmetric_molecule():
 
     assert result.shape == (4,)
     np.testing.assert_allclose(result, result[0], atol=1e-12)
+
+
+def test_gnm_single_atom_returns_zero():
+    """Single-atom GNM diagonal should be zero (no connectivity)."""
+    adj = np.array([[0]], dtype=float)
+    result = get_gnm_encodings(adj)
+
+    assert result.shape == (1,)
+    np.testing.assert_allclose(result, [0.0], atol=1e-12)
+
+
+def test_gnm_single_atom_no_warning():
+    """Single-atom molecule (1x1 zero adjacency) should not produce warnings."""
+    adj = np.array([[0]], dtype=float)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result = get_gnm_encodings(adj)
+
+    assert result.shape == (1,)
+    assert result[0] == 0.0

--- a/gt_pyg/data/utils.py
+++ b/gt_pyg/data/utils.py
@@ -225,6 +225,10 @@ def get_gnm_encodings(adjacency: np.ndarray) -> np.ndarray:
     Returns:
         np.ndarray: Diagonal of the Kirchhoff pseudoinverse with shape ``[N]``.
     """
+    n = adjacency.shape[0]
+    if n <= 1:
+        return np.zeros(n, dtype=float)
+
     degree = np.diag(adjacency.sum(axis=1))
     kirchhoff = degree - adjacency
     eigenvalues, eigenvectors = np.linalg.eigh(kirchhoff)


### PR DESCRIPTION
## Summary
- Early-return `np.zeros(n)` when adjacency is 1×1, skipping eigendecomposition
- Adds two tests: correct zero result and no RuntimeWarning

## Test plan
- [x] `pytest gt_pyg/data/tests/test_gnm.py` — 4/4 pass