### PR TITLE
Simplify _to_float_sequence: remove unreachable dtype==object branch

### DIFF
--- a/gt_pyg/data/utils.py
+++ b/gt_pyg/data/utils.py
@@ -256,10 +256,8 @@ def _to_float_sequence(
     """
     if isinstance(y_val, (float, int, np.floating, np.integer)):
         return np.array([float(y_val)], dtype=np.float32)
-    arr = np.array(y_val, dtype=np.float32)
-    if arr.dtype == object:  # handle None values
-        arr = np.array([np.nan if v is None else float(v) for v in y_val], dtype=np.float32)
-    return arr
+    cleaned = [np.nan if v is None else float(v) for v in y_val]
+    return np.array(cleaned, dtype=np.float32)
 
 
 def get_tensor_data(


### PR DESCRIPTION
Normalize None→nan before np.array call, removing the NumPy-version-dependent object dtype branch.