### PR TITLE
Fix version parsing for hyphenated tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-> Notice: This is research code that will not necessarily be maintained in the future.  
-> The code is under development, so make sure you are using the most recent version.  
+> Notice: This is research code that will not necessarily be maintained in the future.
+> The code is under development, so make sure you are using the most recent version.
 > We welcome bug reports and PRs but make no guarantees about fixes or responses.
 
 ## DESCRIPTION
@@ -10,7 +10,17 @@
 
 ## INSTALL
 
-Clone the repository, create a virtual environment, and install:
+Install directly from GitHub:
+```bash
+pip install git+https://github.com/pgniewko/gt-pyg.git
+```
+
+To install a specific tagged version (e.g. `v1.6.0-beta.1`):
+```bash
+pip install git+https://github.com/pgniewko/gt-pyg.git@v1.6.0-beta.1
+```
+
+Or clone the repository and install locally:
 ```bash
 git clone https://github.com/pgniewko/gt-pyg.git
 cd gt-pyg
@@ -29,11 +39,6 @@ To install everything (dev + examples):
 pip install -e ".[all]"
 ```
 
-> **Note:** Always activate the virtual environment before using `gt_pyg`:
-> ```bash
-> source .venv/bin/activate
-> ```
-
 ---
 
 ## USAGE
@@ -42,8 +47,7 @@ The following code snippet demonstrates how to test the installation of `gt-pyg`
 
 ```python
 import torch
-from torch_geometric.data import Data
-from gt_pyg.nn.gt_conv import GTConv
+from gt_pyg import GTConv
 
 num_nodes = 10
 num_node_features = 3
@@ -72,7 +76,7 @@ with columns `SMILES` and `logS`, you can prepare a `DataLoader` object as follo
 ```python
 import pandas as pd
 from torch_geometric.loader import DataLoader
-from gt_pyg.data import get_tensor_data
+from gt_pyg import get_tensor_data
 
 dataset = pd.read_csv('solubility.csv')
 tr_dataset = get_tensor_data(dataset['SMILES'].tolist(), dataset['logS'].tolist())
@@ -83,7 +87,7 @@ train_loader = DataLoader(tr_dataset, batch_size=256)
 
 ## Public API
 
-### Model
+### Model (`gt_pyg.nn`)
 
 | Symbol | Description |
 |--------|-------------|
@@ -92,7 +96,7 @@ train_loader = DataLoader(tr_dataset, batch_size=256)
 | `MLP` | Multi-layer perceptron used in readout heads |
 | `GraphTransformerNet.from_config(config)` | Construct a model from a config dict |
 
-### Checkpointing & Utilities
+### Checkpointing & Utilities (`gt_pyg.nn`)
 
 | Symbol | Description |
 |--------|-------------|
@@ -103,14 +107,17 @@ train_loader = DataLoader(tr_dataset, batch_size=256)
 | `model.unfreeze(components)` | Unfreeze parameters |
 | `model.get_frozen_status()` | Dict of frozen/unfrozen components |
 
-### Data
+### Data (`gt_pyg.data`)
 
 | Symbol | Description |
 |--------|-------------|
 | `get_tensor_data(x_smiles, y)` | SMILES + labels to list of PyG `Data` objects |
 | `get_atom_feature_dim()` | Dimensionality of the atom feature vector |
+| `get_bond_feature_dim()` | Dimensionality of the bond feature vector |
 | `get_gnm_encodings(adjacency)` | Kirchhoff pseudoinverse diagonal (GNM) |
 | `canonicalize_smiles(smiles)` | Canonical SMILES string |
+
+`GraphTransformerNet`, `GTConv`, `MLP`, and `get_tensor_data` are also available via the top-level `gt_pyg` import.
 
 ---
 
@@ -118,8 +125,11 @@ train_loader = DataLoader(tr_dataset, batch_size=256)
 
 ### Installation (dev)
 
-First, activate the virtual environment, then install in editable mode with dev dependencies:
+Clone the repository, create a virtual environment, and install in editable mode with dev dependencies:
 ```bash
+git clone https://github.com/pgniewko/gt-pyg.git
+cd gt-pyg
+python -m venv .venv
 source .venv/bin/activate
 pip install -e ".[dev]"
 ```
@@ -134,7 +144,7 @@ pytest gt_pyg/ -v
 
 ## REFERENCES
 
-1. [A Generalization of Transformer Networks to Graphs](https://arxiv.org/abs/2012.09699)  
+1. [A Generalization of Transformer Networks to Graphs](https://arxiv.org/abs/2012.09699)
 2. [A Gated Graph Transformer for Protein Complex Structure Quality Assessment
    (Chen et al., 2023, *Bioinformatics*)](https://academic.oup.com/bioinformatics/article/39/Supplement_1/i308/7210460)
 
@@ -142,8 +152,8 @@ pytest gt_pyg/ -v
 
 ## COPYRIGHT NOTICE
 
-Copyright (C) 2023-Present   
-**Pawel Gniewek**  
-Email: gniewko.pablo@gmail.com  
-License: MIT  
+Copyright (C) 2023-Present
+**Pawel Gniewek**
+Email: gniewko.pablo@gmail.com
+License: MIT
 All rights reserved.

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,54 @@
 from setuptools import setup, find_packages
 import os
+import re
+import subprocess
 
-_version_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gt_pyg", "_version.py")
-_ns = {"__file__": _version_path}
-with open(_version_path) as _f:
-    exec(_f.read(), _ns)
+
+def _normalize_prerelease(ver):
+    """Convert common pre-release tag formats to PEP 440."""
+    ver = re.sub(r"[-.]?alpha[.-]?", "a", ver)
+    ver = re.sub(r"[-.]?beta[.-]?", "b", ver)
+    ver = re.sub(r"[-.]?rc[.-]?", "rc", ver)
+    return ver
+
+
+def _get_version_from_git():
+    """Get version from git describe.
+
+    At install time importlib.metadata can return stale data from a
+    previous installation, so setup.py must resolve the version
+    directly from git.
+    """
+    try:
+        repo_dir = os.path.dirname(os.path.abspath(__file__))
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--long"],
+            capture_output=True,
+            text=True,
+            cwd=repo_dir,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr)
+
+        desc = result.stdout.strip().lstrip("v")
+        parts = desc.rsplit("-", 2)
+        if len(parts) != 3 or not parts[2].startswith("g"):
+            raise RuntimeError(f"Cannot parse git describe output: {desc!r}")
+
+        ver, distance, sha = parts[0], parts[1], parts[2][1:]
+        ver = _normalize_prerelease(ver)
+
+        if int(distance) == 0:
+            return ver
+        return f"{ver}.dev{distance}+{sha}"
+
+    except Exception:
+        return "unknown"
+
 
 setup(
     name="gt_pyg",
-    version=_ns["__version__"],
+    version=_get_version_from_git(),
     description="Implementation of the Graph Transformer architecture in Pytorch-geometric",
     packages=find_packages(exclude=["tests*", "*.tests", "*.tests.*"]),
     install_requires=[


### PR DESCRIPTION
## Summary
- **setup.py** resolves version directly from `git describe`, bypassing `importlib.metadata` which returned stale data at install time (e.g. `1.6.0` instead of `1.6.0b1`)
- Replaced fragile regex with `rsplit("-", 2)` to correctly parse tags containing hyphens (e.g. `v1.6.0-beta.1`)
- Added `_normalize_prerelease()` to convert tag formats to PEP 440 (`1.6.0-beta.1` → `1.6.0b1`)
- Revised README: added `pip install git+...` instructions, fixed usage examples to use top-level imports, clarified public API import paths, added `get_bond_feature_dim` to API table

Closes #65

## Test plan
- [x] `pip install -e .` now reports `gt-pyg-1.6.0b1` (was `1.6.0`)
- [x] `python -c "import gt_pyg; print(gt_pyg.__version__)"` returns `1.6.0b1`
- [x] All 178 tests pass