### PR TITLE
Expose feature dim functions in top-level API and fix logger in data/utils

### DIFF
--- a/gt_pyg/__init__.py
+++ b/gt_pyg/__init__.py
@@ -3,6 +3,8 @@ from gt_pyg.nn.model import GraphTransformerNet
 from gt_pyg.nn.gt_conv import GTConv
 from gt_pyg.nn.mlp import MLP
 from gt_pyg.data.utils import get_tensor_data
+from gt_pyg.data.atom_features import get_atom_feature_dim
+from gt_pyg.data.bond_features import get_bond_feature_dim
 
 __all__ = [
     "__version__",
@@ -10,4 +12,6 @@ __all__ = [
     "GTConv",
     "MLP",
     "get_tensor_data",
+    "get_atom_feature_dim",
+    "get_bond_feature_dim",
 ]

--- a/gt_pyg/data/utils.py
+++ b/gt_pyg/data/utils.py
@@ -2,6 +2,8 @@
 import logging
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
+logger = logging.getLogger(__name__)
+
 # Third-party
 import numpy as np
 import torch
@@ -76,7 +78,7 @@ def _canonicalize_mol(
                     atom.SetFormalCharge(0)
                     new_hcount = hcount - chg
                     if new_hcount < 0:
-                        logging.warning(
+                        logger.warning(
                             "Charge neutralization would set negative H count "
                             "(%d) on atom %d; clamping to 0",
                             new_hcount, at_idx,
@@ -88,7 +90,7 @@ def _canonicalize_mol(
         return mol
 
     except Exception as e:
-        logging.warning(f"Failed to canonicalize SMILES '{smiles}': {e}")
+        logger.warning(f"Failed to canonicalize SMILES '{smiles}': {e}")
         return None
 
 
@@ -309,7 +311,7 @@ def get_tensor_data(
         try:
             rdPartialCharges.ComputeGasteigerCharges(mol)
         except Exception as e:
-            logging.warning("Gasteiger charge computation failed for '%s': %s", smiles, e)
+            logger.warning("Gasteiger charge computation failed for '%s': %s", smiles, e)
 
         # Compute pharmacophore flags for entire molecule
         pharmacophore_flags = get_pharmacophore_flags(mol)


### PR DESCRIPTION
## Summary
- Export `get_atom_feature_dim` and `get_bond_feature_dim` from top-level `gt_pyg` package so users can do `from gt_pyg import get_atom_feature_dim` (#62)
- Replace direct `logging.warning()` calls in `data/utils.py` with a module-level `logger` to enable per-module log filtering (#63)

Closes #62
Closes #63

## Test plan
- [x] All 178 tests pass
- [x] Verified `from gt_pyg import get_atom_feature_dim, get_bond_feature_dim` works