### PR TITLE
Make source version resolution consistent

### DIFF
--- a/gt_pyg/_version.py
+++ b/gt_pyg/_version.py
@@ -1,7 +1,8 @@
-"""Derive a PEP 440 version string from package metadata or Git."""
+"""Derive a PEP 440 version string from Git or installed metadata."""
 
 import os
 import re
+import subprocess
 
 
 def _normalize_prerelease(ver: str) -> str:
@@ -20,56 +21,61 @@ def _normalize_prerelease(ver: str) -> str:
     return ver
 
 
+def _get_version_from_git() -> str:
+    """Return the git-derived version for a source checkout."""
+    repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    result = subprocess.run(
+        ["git", "describe", "--tags", "--long"],
+        capture_output=True,
+        text=True,
+        cwd=repo_dir,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+
+    # git describe --tags --long  ->  v1.2.3-N-ghash
+    # Use rsplit to split from the right, so tags containing
+    # hyphens (e.g. v1.6.0-beta.1) are handled correctly.
+    desc = result.stdout.strip().lstrip("v")
+    parts = desc.rsplit("-", 2)
+    if len(parts) != 3 or not parts[2].startswith("g"):
+        raise RuntimeError(f"Cannot parse git describe output: {desc!r}")
+
+    ver, distance, sha = parts[0], parts[1], parts[2][1:]  # strip 'g' prefix
+    ver = _normalize_prerelease(ver)
+
+    if int(distance) == 0:
+        return ver
+    return f"{ver}.dev{distance}+{sha}"
+
+
+def _get_version_from_metadata() -> str:
+    """Return the installed distribution version."""
+    from importlib.metadata import version
+
+    return version("gt_pyg")
+
+
 def _get_version() -> str:
     """Return a PEP 440-compliant version string.
 
     Resolution order:
 
-    1. ``importlib.metadata`` — fast, no subprocess; works for installed
-       packages and in environments without git (Docker, CI tarballs).
-    2. ``git describe --tags --long`` — used during local development in
-       a git checkout where the package may not be installed.
-    3. ``"unknown"`` — last resort.
+    1. ``git describe --tags --long`` in a source checkout.
+    2. ``importlib.metadata`` for installed packages / non-git environments.
+    3. ``"0+unknown"`` as a final fallback.
     """
-    # 1. Try installed package metadata first (no subprocess needed)
+    repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if os.path.isdir(os.path.join(repo_dir, ".git")):
+        try:
+            return _get_version_from_git()
+        except Exception:
+            pass
+
     try:
-        from importlib.metadata import version
-
-        return version("gt_pyg")
+        return _get_version_from_metadata()
     except Exception:
-        pass
-
-    # 2. Fall back to git describe for development checkouts
-    try:
-        import subprocess
-
-        repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        result = subprocess.run(
-            ["git", "describe", "--tags", "--long"],
-            capture_output=True,
-            text=True,
-            cwd=repo_dir,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(result.stderr)
-
-        # git describe --tags --long  →  v1.2.3-N-ghash
-        # Use rsplit to split from the right, so tags containing
-        # hyphens (e.g. v1.6.0-beta.1) are handled correctly.
-        desc = result.stdout.strip().lstrip("v")
-        parts = desc.rsplit("-", 2)
-        if len(parts) != 3 or not parts[2].startswith("g"):
-            raise RuntimeError(f"Cannot parse git describe output: {desc!r}")
-
-        ver, distance, sha = parts[0], parts[1], parts[2][1:]  # strip 'g' prefix
-        ver = _normalize_prerelease(ver)
-
-        if int(distance) == 0:
-            return ver
-        return f"{ver}.dev{distance}+{sha}"
-
-    except Exception:
-        return "unknown"
+        return "0+unknown"
 
 
 __version__: str = _get_version()

--- a/gt_pyg/nn/tests/test_model.py
+++ b/gt_pyg/nn/tests/test_model.py
@@ -1,11 +1,13 @@
 """Tests for GraphTransformerNet freeze/unfreeze and checkpoint functionality."""
 
 import logging
+import importlib.metadata
 
 import pytest
 import torch
 
 import gt_pyg
+import gt_pyg._version as version_mod
 from gt_pyg.nn import GraphTransformerNet, get_checkpoint_info, load_checkpoint
 
 
@@ -243,6 +245,31 @@ def test_version_is_defined():
     """gt_pyg.__version__ is a non-empty string."""
     assert isinstance(gt_pyg.__version__, str)
     assert gt_pyg.__version__ != ""
+
+
+def test_version_prefers_git_in_source_checkout(monkeypatch):
+    """Source checkouts should use git instead of potentially stale metadata."""
+
+    def fake_git_version():
+        return "1.2.3.dev4+abc1234"
+
+    def fail_metadata(_name):
+        raise AssertionError("metadata lookup should not be used in a git checkout")
+
+    monkeypatch.setattr(version_mod, "_get_version_from_git", fake_git_version)
+    monkeypatch.setattr(importlib.metadata, "version", fail_metadata)
+    monkeypatch.setattr(version_mod.os.path, "isdir", lambda path: path.endswith(".git"))
+
+    assert version_mod._get_version() == "1.2.3.dev4+abc1234"
+
+
+def test_version_falls_back_to_metadata_outside_git(monkeypatch):
+    """Installed packages without git metadata should use importlib.metadata."""
+
+    monkeypatch.setattr(version_mod.os.path, "isdir", lambda path: False)
+    monkeypatch.setattr(importlib.metadata, "version", lambda _name: "9.9.9")
+
+    assert version_mod._get_version() == "9.9.9"
 
 
 def test_checkpoint_saves_version(model, tmp_path):

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def _get_version_from_git():
         return f"{ver}.dev{distance}+{sha}"
 
     except Exception:
-        return "unknown"
+        return "0+unknown"
 
 
 setup(


### PR DESCRIPTION
## Summary
Prefer git-derived versions in source checkouts, keep a valid fallback for non-git installs, and add regression coverage for version resolution order.