### PR TITLE
Add optional latent return to forward

### DIFF
--- a/gt_pyg/nn/model.py
+++ b/gt_pyg/nn/model.py
@@ -256,7 +256,8 @@ class GraphTransformerNet(nn.Module):
         edge_attr: Optional[Tensor],
         batch: Union[Batch, Tensor],
         zero_var: bool = False,
-    ) -> Tuple[Tensor, Tensor]:
+        return_latent: bool = False,
+    ) -> Union[Tuple[Tensor, Tensor], Tuple[Tensor, Tensor, Tensor]]:
         """Forward pass with variational (reparameterization) sampling.
 
         In training mode (``zero_var=False``), predictions are stochastic::
@@ -273,9 +274,14 @@ class GraphTransformerNet(nn.Module):
                 Required if ``edge_dim_in`` was set.
             batch: ``Batch`` object or batch-index tensor ``[num_nodes]``.
             zero_var: If True, skip sampling even during training.
+            return_latent: If True, also return the graph-level latent code
+                after readout normalization and before head dropout.
 
         Returns:
-            (prediction, log_var) — both ``[batch_size, num_tasks]``.
+            By default returns ``(prediction, log_var)`` — both
+            ``[batch_size, num_tasks]``. If ``return_latent=True``, returns
+            ``(prediction, log_var, latent)`` where ``latent`` has shape
+            ``[batch_size, num_aggrs * hidden_dim]``.
         """
         # Node embedding
         h = self.node_emb(x)  # [N, H]
@@ -303,8 +309,8 @@ class GraphTransformerNet(nn.Module):
         g = self.global_pool(h, batch_index)  # [B, num_aggrs * H]
 
         # Readout norm + dropout
-        g = self.readout_norm(g)
-        g = self.readout_dropout(g)
+        latent = self.readout_norm(g)
+        g = self.readout_dropout(latent)
 
         # Heads
         mu = self.mu_mlp(g)            # [B, T]
@@ -320,6 +326,8 @@ class GraphTransformerNet(nn.Module):
         else:
             pred = mu                   # deterministic mean
 
+        if return_latent:
+            return pred, log_var, latent
         return pred, log_var
 
 
@@ -563,4 +571,3 @@ class GraphTransformerNet(nn.Module):
                 )
 
         self.load_state_dict(checkpoint["model_state_dict"], strict=strict)
-

--- a/gt_pyg/nn/tests/test_model.py
+++ b/gt_pyg/nn/tests/test_model.py
@@ -213,6 +213,51 @@ def test_get_config(model):
     assert len(model2.gt_layers) == len(model.gt_layers)
 
 
+# ---- Forward API Tests ----
+
+def test_forward_return_latent_is_opt_in_and_backward_compatible(model, sample_input):
+    """Default outputs remain unchanged when latent return is requested."""
+    model.eval()
+
+    with torch.no_grad():
+        out1, log_var1 = model(**sample_input, zero_var=True)
+        out2, log_var2, latent = model(
+            **sample_input,
+            zero_var=True,
+            return_latent=True,
+        )
+
+    assert torch.allclose(out1, out2)
+    assert torch.allclose(log_var1, log_var2)
+    assert latent.shape == (1, model.num_aggrs * model.hidden_dim)
+
+
+def test_forward_return_latent_returns_pre_dropout_embedding(model, sample_input):
+    """Returned latent matches the normalized pooled graph embedding."""
+    model.eval()
+
+    with torch.no_grad():
+        h = model.node_emb(sample_input["x"])
+        h = model.input_norm(h)
+        h = model.input_dropout(h)
+
+        e = model.edge_emb(sample_input["edge_attr"])
+        for gt_layer in model.gt_layers:
+            h, e = gt_layer(x=h, edge_index=sample_input["edge_index"], edge_attr=e)
+
+        batch_index = model._get_batch_index(sample_input["batch"])
+        pooled = model.global_pool(h, batch_index)
+        expected_latent = model.readout_norm(pooled)
+
+        _out, _log_var, latent = model(
+            **sample_input,
+            zero_var=True,
+            return_latent=True,
+        )
+
+    assert torch.allclose(latent, expected_latent)
+
+
 # ---- Integration Test ----
 
 def test_transfer_learning(model, sample_input, tmp_path):

--- a/gt_pyg/nn/tests/test_model.py
+++ b/gt_pyg/nn/tests/test_model.py
@@ -213,7 +213,7 @@ def test_get_config(model):
     assert len(model2.gt_layers) == len(model.gt_layers)
 
 
-# ---- Forward API Tests ----
+# ---- Forward Pass API Tests ----
 
 def test_forward_return_latent_is_opt_in_and_backward_compatible(model, sample_input):
     """Default outputs remain unchanged when latent return is requested."""


### PR DESCRIPTION
Adds an opt-in latent return from GraphTransformerNet.forward and covers it with tests.