### PR TITLE
Deduplicate version parsing helpers

### DIFF
--- a/gt_pyg/_version.py
+++ b/gt_pyg/_version.py
@@ -1,81 +1,11 @@
 """Derive a PEP 440 version string from Git or installed metadata."""
 
-import os
-import re
-import subprocess
-
-
-def _normalize_prerelease(ver: str) -> str:
-    """Convert common pre-release tag formats to PEP 440.
-
-    Examples:
-        1.6.0-beta.1  → 1.6.0b1
-        1.6.0-alpha.2 → 1.6.0a2
-        1.6.0-rc.3    → 1.6.0rc3
-        2.0.0a1       → 2.0.0a1   (already compliant, unchanged)
-        1.5.8         → 1.5.8     (no pre-release, unchanged)
-    """
-    ver = re.sub(r"[-.]?alpha[.-]?", "a", ver)
-    ver = re.sub(r"[-.]?beta[.-]?", "b", ver)
-    ver = re.sub(r"[-.]?rc[.-]?", "rc", ver)
-    return ver
-
-
-def _get_version_from_git() -> str:
-    """Return the git-derived version for a source checkout."""
-    repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    result = subprocess.run(
-        ["git", "describe", "--tags", "--long"],
-        capture_output=True,
-        text=True,
-        cwd=repo_dir,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(result.stderr)
-
-    # git describe --tags --long  ->  v1.2.3-N-ghash
-    # Use rsplit to split from the right, so tags containing
-    # hyphens (e.g. v1.6.0-beta.1) are handled correctly.
-    desc = result.stdout.strip().lstrip("v")
-    parts = desc.rsplit("-", 2)
-    if len(parts) != 3 or not parts[2].startswith("g"):
-        raise RuntimeError(f"Cannot parse git describe output: {desc!r}")
-
-    ver, distance, sha = parts[0], parts[1], parts[2][1:]  # strip 'g' prefix
-    ver = _normalize_prerelease(ver)
-
-    if int(distance) == 0:
-        return ver
-    return f"{ver}.dev{distance}+{sha}"
-
-
-def _get_version_from_metadata() -> str:
-    """Return the installed distribution version."""
-    from importlib.metadata import version
-
-    return version("gt_pyg")
-
-
-def _get_version() -> str:
-    """Return a PEP 440-compliant version string.
-
-    Resolution order:
-
-    1. ``git describe --tags --long`` in a source checkout.
-    2. ``importlib.metadata`` for installed packages / non-git environments.
-    3. ``"0+unknown"`` as a final fallback.
-    """
-    repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    if os.path.isdir(os.path.join(repo_dir, ".git")):
-        try:
-            return _get_version_from_git()
-        except Exception:
-            pass
-
-    try:
-        return _get_version_from_metadata()
-    except Exception:
-        return "0+unknown"
+from ._version_utils import (
+    _get_version,
+    _get_version_from_git,
+    _get_version_from_metadata,
+    _normalize_prerelease,
+)
 
 
 __version__: str = _get_version()

--- a/gt_pyg/_version_utils.py
+++ b/gt_pyg/_version_utils.py
@@ -1,0 +1,62 @@
+"""Shared helpers for deriving a PEP 440 version string."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+
+
+def _normalize_prerelease(ver: str) -> str:
+    """Convert common pre-release tag formats to PEP 440."""
+    ver = re.sub(r"[-.]?alpha[.-]?", "a", ver)
+    ver = re.sub(r"[-.]?beta[.-]?", "b", ver)
+    ver = re.sub(r"[-.]?rc[.-]?", "rc", ver)
+    return ver
+
+
+def _get_version_from_git() -> str:
+    """Return the git-derived version for a source checkout."""
+    repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    result = subprocess.run(
+        ["git", "describe", "--tags", "--long"],
+        capture_output=True,
+        text=True,
+        cwd=repo_dir,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+
+    desc = result.stdout.strip().lstrip("v")
+    parts = desc.rsplit("-", 2)
+    if len(parts) != 3 or not parts[2].startswith("g"):
+        raise RuntimeError(f"Cannot parse git describe output: {desc!r}")
+
+    ver, distance, sha = parts[0], parts[1], parts[2][1:]
+    ver = _normalize_prerelease(ver)
+
+    if int(distance) == 0:
+        return ver
+    return f"{ver}.dev{distance}+{sha}"
+
+
+def _get_version_from_metadata() -> str:
+    """Return the installed distribution version."""
+    from importlib.metadata import version
+
+    return version("gt_pyg")
+
+
+def _get_version() -> str:
+    """Resolve a version from git, then package metadata, then a fallback."""
+    repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if os.path.isdir(os.path.join(repo_dir, ".git")):
+        try:
+            return _get_version_from_git()
+        except Exception:
+            pass
+
+    try:
+        return _get_version_from_metadata()
+    except Exception:
+        return "0+unknown"

--- a/gt_pyg/nn/tests/test_model.py
+++ b/gt_pyg/nn/tests/test_model.py
@@ -2,12 +2,14 @@
 
 import logging
 import importlib.metadata
+from types import SimpleNamespace
 
 import pytest
 import torch
 
 import gt_pyg
 import gt_pyg._version as version_mod
+import gt_pyg._version_utils as version_utils
 from gt_pyg.nn import GraphTransformerNet, get_checkpoint_info, load_checkpoint
 
 
@@ -292,6 +294,49 @@ def test_version_is_defined():
     assert gt_pyg.__version__ != ""
 
 
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("1.6.0-alpha.2", "1.6.0a2"),
+        ("1.6.0-beta.1", "1.6.0b1"),
+        ("1.6.0-rc.3", "1.6.0rc3"),
+    ],
+)
+def test_version_utils_normalizes_prerelease_tags(version, expected):
+    """Shared version helper converts common prerelease tags to PEP 440."""
+    assert version_utils._normalize_prerelease(version) == expected
+
+
+@pytest.mark.parametrize(
+    ("stdout", "expected"),
+    [
+        ("v1.6.0-beta.1-0-gabc123\n", "1.6.0b1"),
+        ("v1.6.0-beta.1-2-gabc123\n", "1.6.0b1.dev2+abc123"),
+    ],
+)
+def test_version_utils_parses_git_describe(monkeypatch, stdout, expected):
+    """Shared version helper parses git describe output for setup and runtime."""
+
+    def fake_run(*_args, **_kwargs):
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(version_utils.subprocess, "run", fake_run)
+
+    assert version_utils._get_version_from_git() == expected
+
+
+def test_version_utils_rejects_malformed_git_describe(monkeypatch):
+    """Malformed git describe output fails before setup/runtime fallback."""
+
+    def fake_run(*_args, **_kwargs):
+        return SimpleNamespace(returncode=0, stdout="v1.6.0-beta.1\n", stderr="")
+
+    monkeypatch.setattr(version_utils.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="Cannot parse git describe output"):
+        version_utils._get_version_from_git()
+
+
 def test_version_prefers_git_in_source_checkout(monkeypatch):
     """Source checkouts should use git instead of potentially stale metadata."""
 
@@ -301,9 +346,13 @@ def test_version_prefers_git_in_source_checkout(monkeypatch):
     def fail_metadata(_name):
         raise AssertionError("metadata lookup should not be used in a git checkout")
 
-    monkeypatch.setattr(version_mod, "_get_version_from_git", fake_git_version)
+    monkeypatch.setattr(version_utils, "_get_version_from_git", fake_git_version)
     monkeypatch.setattr(importlib.metadata, "version", fail_metadata)
-    monkeypatch.setattr(version_mod.os.path, "isdir", lambda path: path.endswith(".git"))
+    monkeypatch.setattr(
+        version_utils.os.path,
+        "isdir",
+        lambda path: path.endswith(".git"),
+    )
 
     assert version_mod._get_version() == "1.2.3.dev4+abc1234"
 
@@ -311,7 +360,7 @@ def test_version_prefers_git_in_source_checkout(monkeypatch):
 def test_version_falls_back_to_metadata_outside_git(monkeypatch):
     """Installed packages without git metadata should use importlib.metadata."""
 
-    monkeypatch.setattr(version_mod.os.path, "isdir", lambda path: False)
+    monkeypatch.setattr(version_utils.os.path, "isdir", lambda path: False)
     monkeypatch.setattr(importlib.metadata, "version", lambda _name: "9.9.9")
 
     assert version_mod._get_version() == "9.9.9"

--- a/setup.py
+++ b/setup.py
@@ -1,54 +1,31 @@
-from setuptools import setup, find_packages
-import os
-import re
-import subprocess
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+from setuptools import find_packages, setup
 
 
-def _normalize_prerelease(ver):
-    """Convert common pre-release tag formats to PEP 440."""
-    ver = re.sub(r"[-.]?alpha[.-]?", "a", ver)
-    ver = re.sub(r"[-.]?beta[.-]?", "b", ver)
-    ver = re.sub(r"[-.]?rc[.-]?", "rc", ver)
-    return ver
+def _load_version_utils():
+    version_utils_path = (
+        Path(__file__).resolve().parent / "gt_pyg" / "_version_utils.py"
+    )
+    spec = spec_from_file_location("gt_pyg_setup_version_utils", version_utils_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load version helpers from {version_utils_path}")
+
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
-def _get_version_from_git():
-    """Get version from git describe.
-
-    At install time importlib.metadata can return stale data from a
-    previous installation, so setup.py must resolve the version
-    directly from git.
-    """
-    try:
-        repo_dir = os.path.dirname(os.path.abspath(__file__))
-        result = subprocess.run(
-            ["git", "describe", "--tags", "--long"],
-            capture_output=True,
-            text=True,
-            cwd=repo_dir,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(result.stderr)
-
-        desc = result.stdout.strip().lstrip("v")
-        parts = desc.rsplit("-", 2)
-        if len(parts) != 3 or not parts[2].startswith("g"):
-            raise RuntimeError(f"Cannot parse git describe output: {desc!r}")
-
-        ver, distance, sha = parts[0], parts[1], parts[2][1:]
-        ver = _normalize_prerelease(ver)
-
-        if int(distance) == 0:
-            return ver
-        return f"{ver}.dev{distance}+{sha}"
-
-    except Exception:
-        return "0+unknown"
+try:
+    PACKAGE_VERSION = _load_version_utils()._get_version_from_git()
+except Exception:
+    PACKAGE_VERSION = "0+unknown"
 
 
 setup(
     name="gt_pyg",
-    version=_get_version_from_git(),
+    version=PACKAGE_VERSION,
     description="Implementation of the Graph Transformer architecture in Pytorch-geometric",
     packages=find_packages(exclude=["tests*", "*.tests", "*.tests.*"]),
     install_requires=[


### PR DESCRIPTION
## Summary
- Move shared version parsing into gt_pyg._version_utils.
- Make runtime versioning and setup.py use the same helper without importing gt_pyg during setup.
- Add focused coverage for prerelease and git describe parsing.

Fixes #90.

## Tests
- .venv/bin/python setup.py --version
- .venv/bin/python -m pytest gt_pyg/nn/tests/test_model.py -q
- .venv/bin/python -m pytest gt_pyg/nn/tests/test_checkpoint.py -q