### PR TITLE
Document and test the probabilistic mode output

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ current export lists, see [`gt_pyg/__init__.py`](gt_pyg/__init__.py),
 | `model.get_config()` / `GraphTransformerNet.from_config(config)` | Round-trip model configs for reproducible reconstruction |
 | `model.num_parameters()` | Number of trainable parameters |
 
+`GraphTransformerNet.forward(...)` returns `(prediction, log_var)`. In
+training mode, `prediction` is sampled from the learned Gaussian readout unless
+`zero_var=True`; in eval mode, `prediction` is always the deterministic mean
+`mu`. The returned `log_var` is always the learned, clamped log-variance head
+output and can be used for Gaussian losses or uncertainty estimates.
+`zero_var=True` skips sampling only; it does not zero or suppress `log_var`.
+
 ### Checkpointing & Utilities (`gt_pyg.nn`)
 
 | Symbol | Description |

--- a/gt_pyg/nn/model.py
+++ b/gt_pyg/nn/model.py
@@ -30,7 +30,9 @@ class GraphTransformerNet(nn.Module):
 
     This enables gradient-based optimization of probabilistic objectives
     (e.g. Gaussian NLL loss).  Set ``zero_var=True`` to disable sampling
-    and return the deterministic mean instead.
+    and return the deterministic mean instead.  The ``zero_var`` flag only
+    controls whether ``prediction`` is sampled; the returned ``log_var`` still
+    comes from the learned variance head.
 
     During **evaluation** the forward pass always returns the deterministic
     mean.  ``log_var`` is always returned for loss computation or uncertainty
@@ -260,12 +262,15 @@ class GraphTransformerNet(nn.Module):
     ) -> Union[Tuple[Tensor, Tensor], Tuple[Tensor, Tensor, Tensor]]:
         """Forward pass with variational (reparameterization) sampling.
 
-        In training mode (``zero_var=False``), predictions are stochastic::
+        In training mode with ``zero_var=False``, ``prediction`` is a
+        stochastic sample from the learned Gaussian::
 
             pred = mu + exp(0.5 * log_var) * epsilon,  epsilon ~ N(0, 1)
 
-        In eval mode (or ``zero_var=True``), predictions are the
-        deterministic mean ``mu``.  ``log_var`` is always returned.
+        In eval mode, or when ``zero_var=True``, ``prediction`` is the
+        deterministic mean ``mu``.  ``log_var`` is always returned from the
+        learned variance head; ``zero_var=True`` does not replace it with
+        zeros.
 
         Args:
             x: Node features ``[num_nodes, node_dim_in]``.
@@ -273,7 +278,9 @@ class GraphTransformerNet(nn.Module):
             edge_attr: Edge features ``[num_edges, edge_dim_in]``.
                 Required if ``edge_dim_in`` was set.
             batch: ``Batch`` object or batch-index tensor ``[num_nodes]``.
-            zero_var: If True, skip sampling even during training.
+            zero_var: If True, skip sampling even during training.  This
+                affects only ``prediction`` and leaves returned ``log_var``
+                unchanged.
             return_latent: If True, also return the graph-level latent code
                 after readout normalization and before head dropout.
 

--- a/gt_pyg/nn/tests/test_model.py
+++ b/gt_pyg/nn/tests/test_model.py
@@ -217,6 +217,54 @@ def test_get_config(model):
 
 # ---- Forward Pass API Tests ----
 
+def test_forward_training_samples_and_eval_is_deterministic(sample_input):
+    """Training samples from the variance head; eval and zero_var return mu."""
+    torch.manual_seed(1234)
+    model = GraphTransformerNet(
+        node_dim_in=16,
+        edge_dim_in=8,
+        hidden_dim=32,
+        num_gt_layers=2,
+        num_heads=4,
+        norm="ln",
+        dropout=0.0,
+        head_dropout=0.0,
+    )
+
+    with torch.no_grad():
+        for param in model.log_var_mlp.parameters():
+            param.zero_()
+        model.log_var_mlp.output_layer.bias.fill_(0.5)
+
+    model.train()
+    with torch.no_grad():
+        train_pred1, train_log_var1 = model(**sample_input)
+        train_pred2, train_log_var2 = model(**sample_input)
+
+    assert not torch.allclose(train_pred1, train_pred2)
+    assert torch.allclose(train_log_var1, train_log_var2)
+    assert torch.allclose(train_log_var1, torch.full_like(train_log_var1, 0.5))
+
+    model.eval()
+    with torch.no_grad():
+        eval_pred1, eval_log_var1 = model(**sample_input)
+        eval_pred2, eval_log_var2 = model(**sample_input)
+
+    assert torch.allclose(eval_pred1, eval_pred2)
+    assert torch.allclose(eval_log_var1, eval_log_var2)
+    assert torch.allclose(eval_log_var1, torch.full_like(eval_log_var1, 0.5))
+
+    model.train()
+    with torch.no_grad():
+        zero_var_pred1, zero_var_log_var1 = model(**sample_input, zero_var=True)
+        zero_var_pred2, zero_var_log_var2 = model(**sample_input, zero_var=True)
+
+    assert torch.allclose(zero_var_pred1, zero_var_pred2)
+    assert torch.allclose(zero_var_pred1, eval_pred1)
+    assert torch.allclose(zero_var_log_var1, zero_var_log_var2)
+    assert torch.allclose(zero_var_log_var1, torch.full_like(zero_var_log_var1, 0.5))
+
+
 def test_forward_return_latent_is_opt_in_and_backward_compatible(model, sample_input):
     """Default outputs remain unchanged when latent return is requested."""
     model.eval()


### PR DESCRIPTION
Document the probabilistic output so the users are not confused about the model's behavior. 

Closes #92 