### PR TITLE
Protect checkpoint provenance

### DIFF
--- a/gt_pyg/_version_utils.py
+++ b/gt_pyg/_version_utils.py
@@ -36,7 +36,7 @@ def _get_version_from_git() -> str:
     ver = _normalize_prerelease(ver)
 
     if int(distance) == 0:
-        return ver
+        return f"{ver}+{sha}"
     return f"{ver}.dev{distance}+{sha}"
 
 

--- a/gt_pyg/nn/checkpoint.py
+++ b/gt_pyg/nn/checkpoint.py
@@ -23,6 +23,7 @@ def save_checkpoint(
     global_step: Optional[int] = None,
     best_metric: Optional[float] = None,
     extra: Optional[Dict[str, Any]] = None,
+    require_version: bool = True,
 ) -> None:
     """
     Save checkpoint to disk (generic utility).
@@ -37,8 +38,18 @@ def save_checkpoint(
         global_step: Training step.
         best_metric: Best metric value.
         extra: Additional data.
+        require_version: If True, reject checkpoints without usable provenance.
     """
     from datetime import datetime, timezone
+
+    if not __version__ or __version__ == "0+unknown":
+        msg = (
+            "gt-pyg version is unknown; refusing to save checkpoint without "
+            "source provenance."
+        )
+        if require_version:
+            raise RuntimeError(msg)
+        logger.warning(msg)
 
     path = Path(path)
     if path.suffix != ".pt":

--- a/gt_pyg/nn/model.py
+++ b/gt_pyg/nn/model.py
@@ -487,6 +487,7 @@ class GraphTransformerNet(nn.Module):
         global_step: Optional[int] = None,
         best_metric: Optional[float] = None,
         extra: Optional[Dict[str, Any]] = None,
+        require_version: bool = True,
     ) -> None:
         """
         Save checkpoint to disk.
@@ -499,6 +500,7 @@ class GraphTransformerNet(nn.Module):
             global_step: Global training step.
             best_metric: Best validation metric.
             extra: Additional user data.
+            require_version: If True, reject checkpoints without usable provenance.
         """
         from .checkpoint import save_checkpoint
 
@@ -516,6 +518,7 @@ class GraphTransformerNet(nn.Module):
             global_step=global_step,
             best_metric=best_metric,
             extra=merged_extra,
+            require_version=require_version,
         )
 
     @classmethod

--- a/gt_pyg/nn/tests/test_checkpoint.py
+++ b/gt_pyg/nn/tests/test_checkpoint.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from torch import nn
 
+import gt_pyg.nn.checkpoint as checkpoint_mod
 from gt_pyg.nn.checkpoint import save_checkpoint, load_checkpoint, get_checkpoint_info
 
 
@@ -92,6 +93,26 @@ class TestSaveLoad:
         assert ckpt["gt_pyg_version"] == gt_pyg.__version__
         assert "created_at" in ckpt
         assert ckpt["checkpoint_version"] == 1
+
+    def test_unknown_version_rejected_by_default(self, model, tmp_path, monkeypatch):
+        monkeypatch.setattr(checkpoint_mod, "__version__", "0+unknown")
+
+        with pytest.raises(RuntimeError, match="version is unknown"):
+            save_checkpoint(model, tmp_path / "ckpt.pt")
+
+    def test_unknown_version_can_warn_when_relaxed(
+        self, model, tmp_path, monkeypatch, caplog,
+    ):
+        import logging
+
+        monkeypatch.setattr(checkpoint_mod, "__version__", "0+unknown")
+
+        with caplog.at_level(logging.WARNING, logger="gt_pyg.nn.checkpoint"):
+            save_checkpoint(model, tmp_path / "ckpt.pt", require_version=False)
+
+        ckpt = torch.load(tmp_path / "ckpt.pt", map_location="cpu", weights_only=False)
+        assert ckpt["gt_pyg_version"] == "0+unknown"
+        assert any("version is unknown" in msg for msg in caplog.messages)
 
 
 # ---------------------------------------------------------------------------

--- a/gt_pyg/nn/tests/test_model.py
+++ b/gt_pyg/nn/tests/test_model.py
@@ -358,7 +358,7 @@ def test_version_utils_normalizes_prerelease_tags(version, expected):
 @pytest.mark.parametrize(
     ("stdout", "expected"),
     [
-        ("v1.6.0-beta.1-0-gabc123\n", "1.6.0b1"),
+        ("v1.6.0-beta.1-0-gabc123\n", "1.6.0b1+abc123"),
         ("v1.6.0-beta.1-2-gabc123\n", "1.6.0b1.dev2+abc123"),
     ],
 )


### PR DESCRIPTION
Preserve git hashes in checkpoint versions and reject unknown versions by default when saving checkpoints.

Closes #91