### PR TITLE
Trainable aggregators allowed for global pooling

### DIFF
--- a/gt_pyg/nn/model.py
+++ b/gt_pyg/nn/model.py
@@ -7,16 +7,38 @@ import torch
 logger = logging.getLogger(__name__)
 from torch import nn, Tensor
 from torch_geometric.data import Batch
-from torch_geometric.nn.aggr import MultiAggregation
+from torch_geometric.nn.aggr import (
+    AttentionalAggregation,
+    MultiAggregation,
+    PowerMeanAggregation,
+    SoftmaxAggregation,
+)
 
 from .gt_conv import GTConv
 from .mlp import MLP
 from .utils import (
+    VALID_POOL_AGGREGATORS,
     make_norm,
     validate_aggregators,
     validate_dropout,
     validate_num_gt_layers,
 )
+
+
+def _build_pool_aggr(name: str, hidden_dim: int) -> Union[str, nn.Module]:
+    """Resolve a pooling aggregator name to an aggregation for ``MultiAggregation``.
+
+    Trainable readouts: ``"attn"`` (gated attention over nodes) and per-channel
+    learnable ``"softmax"`` / ``"powermean"``.  All other names resolve to PyG's
+    parameter-free aggregations. Every readout outputs ``hidden_dim`` features.
+    """
+    if name == "attn":
+        return AttentionalAggregation(gate_nn=nn.Linear(hidden_dim, 1))
+    if name == "softmax":
+        return SoftmaxAggregation(learn=True, channels=hidden_dim)
+    if name == "powermean":
+        return PowerMeanAggregation(learn=True, channels=hidden_dim)
+    return name
 
 
 class GraphTransformerNet(nn.Module):
@@ -92,7 +114,7 @@ class GraphTransformerNet(nn.Module):
         validate_dropout("head_dropout", resolved_head_dropout)
         validate_num_gt_layers(num_gt_layers)
         validate_aggregators("gt_aggregators", gt_aggregators)
-        validate_aggregators("aggregators", aggregators)
+        validate_aggregators("aggregators", aggregators, valid=VALID_POOL_AGGREGATORS)
 
         if num_tasks <= 0:
             raise ValueError("num_tasks must be >= 1")
@@ -140,7 +162,8 @@ class GraphTransformerNet(nn.Module):
         )
 
         # ---- Global pooling and readout ----
-        self.global_pool = MultiAggregation(aggregators, mode="cat")
+        aggrs = [_build_pool_aggr(a, hidden_dim) for a in aggregators]
+        self.global_pool = MultiAggregation(aggrs, mode="cat")
         self.num_aggrs = len(aggregators)
         head_in_dim = self.num_aggrs * hidden_dim
 
@@ -189,6 +212,7 @@ class GraphTransformerNet(nn.Module):
 
         self.input_norm.reset_parameters()
         self.readout_norm.reset_parameters()
+        self.global_pool.reset_parameters()
         for m in self.gt_layers:
             m.reset_parameters()
         self.mu_mlp.reset_parameters()

--- a/gt_pyg/nn/tests/test_model.py
+++ b/gt_pyg/nn/tests/test_model.py
@@ -513,3 +513,67 @@ def test_head_dropout_saved_in_config():
     m2 = GraphTransformerNet.from_config(config)
     assert m2.readout_dropout.p == 0.3
     assert m2.mu_mlp.dropout_p == 0.3
+
+
+# ---- Trainable Readout Tests ----
+
+TRAINABLE_AGGRS = ["attn", "softmax", "powermean"]
+
+
+def _make_pool_model(aggregators):
+    return GraphTransformerNet(
+        node_dim_in=16, edge_dim_in=8, hidden_dim=32,
+        num_gt_layers=2, num_heads=4, aggregators=aggregators,
+    )
+
+
+def test_trainable_readout_shapes_and_params(sample_input):
+    """Trainable aggregators produce params; each readout is hidden_dim wide."""
+    model = _make_pool_model(["sum", "attn", "softmax", "powermean"])
+    assert model.num_aggrs == 4
+
+    model.eval()
+    pred, log_var, latent = model(**sample_input, return_latent=True)
+    assert pred.shape == (1, 1)
+    assert latent.shape == (1, 4 * model.hidden_dim)
+
+    pool_params = dict(model.global_pool.named_parameters())
+    assert any("gate_nn" in k for k in pool_params)  # attn
+    assert pool_params["aggrs.2.t"].shape == (model.hidden_dim,)  # per-channel softmax
+    assert pool_params["aggrs.3.p"].shape == (model.hidden_dim,)  # per-channel powermean
+
+
+def test_trainable_readout_checkpoint_roundtrip(sample_input, tmp_path):
+    """Trained readout weights survive save/load with strict=True."""
+    model = _make_pool_model(TRAINABLE_AGGRS)
+    model.eval()
+    out1, _ = model(**sample_input)
+
+    model.save_checkpoint(tmp_path / "model.pt")
+    model2, _ = GraphTransformerNet.load_checkpoint(tmp_path / "model.pt", strict=True)
+    model2.eval()
+    out2, _ = model2(**sample_input)
+
+    assert torch.allclose(out1, out2)
+
+
+def test_trainable_readout_freeze(sample_input):
+    """Pooling component freezes/unfreezes and reports real status."""
+    model = _make_pool_model(["attn", "softmax"])
+    assert model.get_frozen_status()["pooling"] is False
+
+    model.freeze("pooling")
+    assert model.get_frozen_status()["pooling"] is True
+    assert all(not p.requires_grad for p in model.global_pool.parameters())
+
+    model.unfreeze("pooling")
+    assert model.get_frozen_status()["pooling"] is False
+
+
+def test_pool_only_aggregators_rejected_for_message_passing():
+    """attn is pooling-only: invalid as gt_aggregators."""
+    with pytest.raises(ValueError, match="gt_aggregators"):
+        GraphTransformerNet(
+            node_dim_in=16, hidden_dim=32, num_heads=4,
+            gt_aggregators=["attn"],
+        )

--- a/gt_pyg/nn/utils.py
+++ b/gt_pyg/nn/utils.py
@@ -20,6 +20,9 @@ VALID_AGGREGATORS = frozenset(
     }
 )
 
+# Trainable readouts only valid for graph-level pooling, not message passing.
+VALID_POOL_AGGREGATORS = VALID_AGGREGATORS | {"attn"}
+
 
 def make_norm(norm: str, dim: int) -> nn.Module:
     """Create a BatchNorm1d ("bn") or LayerNorm ("ln") module of size ``dim``."""
@@ -38,7 +41,11 @@ def validate_dropout(name: str, value: float) -> None:
         raise ValueError(f"{name} must be in [0, 1), got {value}")
 
 
-def validate_aggregators(name: str, aggregators: Sequence[str]) -> None:
+def validate_aggregators(
+    name: str,
+    aggregators: Sequence[str],
+    valid: frozenset = VALID_AGGREGATORS,
+) -> None:
     if isinstance(aggregators, (str, bytes)) or not isinstance(aggregators, (list, tuple)):
         raise ValueError(f"{name} must be a non-empty list or tuple of aggregator names")
     if len(aggregators) == 0:
@@ -50,14 +57,14 @@ def validate_aggregators(name: str, aggregators: Sequence[str]) -> None:
             raise ValueError(f"{name} entries must be strings, got {aggregator!r}")
         if aggregator == "":
             raise ValueError(f"{name} entries must be non-empty strings")
-        if aggregator not in VALID_AGGREGATORS:
+        if aggregator not in valid:
             invalid.append(aggregator)
 
     if invalid:
-        valid = ", ".join(sorted(VALID_AGGREGATORS))
+        valid_names = ", ".join(sorted(valid))
         raise ValueError(
             f"{name} contains unsupported aggregators {invalid!r}; "
-            f"valid aggregators are: {valid}"
+            f"valid aggregators are: {valid_names}"
         )
 
 


### PR DESCRIPTION
This PR extends the global pooling methods to trainable. Previously `softmax` and `powermean` were acceptable but not trainable. Now we make them trainable (one parameter per channel) and attention aggregation. 

Tested on running, saving checkpoints, loading checkpoints, and that aggregation is trainable. If the only aggregator is `attn` then we simply have the attention aggregation -- but can be concat with other, parameter free. 

We do not change message passing aggregation as it doesn't make much sense and may even explode the parameters count. 

One idea to use:
- Train on auxiliary data
- Freeze the encoder, keep the trainable (AttentionAggregation) trainable, with warm start, and fine-tune on the target task only the decoder (head). 